### PR TITLE
Color-series-list property name mistake : "color" and "series" are reversed

### DIFF
--- a/px-vis-pie-chart.html
+++ b/px-vis-pie-chart.html
@@ -100,7 +100,7 @@ Custom property | Description
           id="pie"
           svg="[[svg]]"
           class="absolute"
-          color-series-list="[[colorSeriesList]]"
+          series-color-list="[[seriesColorList]]"
           width="[[width]]"
           height="[[height]]"
           margin="[[margin]]"


### PR DESCRIPTION
Hi,

I am submitting a correction for issue #43 : 

the name of the property color-series-list is wrong in the px-vis-pie-chart component.

It should be series-color-list as defined in px-vis-behavior-colors.html (from px-vis).
