### PR TITLE
Move test runner to test/index.html to make it easier to run locally

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+    <script src="../../web-component-tester/browser.js"></script>
+  </head>
+  <body>
+    <script>
+      // Load and run all tests (.html, .js):
+      WCT.loadSuites([
+        'px-vis-pie-chart-test-fixture.html?wc-shadydom=true&wc-ce=true&wc-shimcssproperties=true',
+        'px-vis-pie-chart-test-fixture.html?dom=shadow'
+      ]);
+    </script>
+</body></html>

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -34,6 +34,6 @@
     }
   },
   "suites": [
-    "test/px-vis-pie-chart-test-fixture.html"
+    "test/index.html"
   ]
 }


### PR DESCRIPTION
We've been moving our WCT test invocation to test/index.html. This lets us have more control over running tests in shadow + shady dom, etc. 

It also allows us to run `polymer serve` and just load the test file directly without running wct. e.g.

```
$ cd px-vis-pie-chart
$ polymer install --variants
$ polymer serve
## Open http://localhost:8000/components/px-vis-pie-chart/test/ and you'll see the tests run, no need to mess with WCT
```