### PR TITLE
Reflect style to attribute

### DIFF
--- a/px-vis-pie-chart.html
+++ b/px-vis-pie-chart.html
@@ -78,7 +78,7 @@ Custom property | Description
           </px-vis-register>
           <!-- popover + svg -->
           <div>
-            <div style="position:relative;width:[[_smallerSide]]px;height:0px;">
+            <div style$="position:relative;width:[[_smallerSide]]px;height:0px;">
               <px-popover
                 id="popover"
                 style="position:relative"
@@ -93,7 +93,7 @@ Custom property | Description
             <!-- Core -->
             <px-vis-svg
               id="svg"
-              style="height:[[_smallerSide]]px;width:[[_smallerSide]]px"
+              style$="height:[[_smallerSide]]px;width:[[_smallerSide]]px"
               width="[[_smallerSide]]"
               height="[[_smallerSide]]"
               offset="[[_center]]"


### PR DESCRIPTION
For future reference because I'm sure we'll see this in other random test failures:

In Polymer 1 land, doing `<div style="[[someFunctionHere]]">` didn't throw an error. In Polymer 2 land, since the code doesn't include the $ in `style$="..."` it tries to set the style property on the div, not reflect the style attribute. In Safari HTMLElement.style is read only and throws an error when you try to set the style property to something else.

When this error appears it comes out of https://github.com/Polymer/polymer/blob/4915b0a0181363eed6685f4274a2001b60f4d352/lib/mixins/property-effects.html#L726