### PR TITLE
Defer drawing of title until colors are applied

### DIFF
--- a/px-vis-pie-chart.html
+++ b/px-vis-pie-chart.html
@@ -326,13 +326,16 @@ Custom property | Description
       _forceColorsUpdate: {
         type: Number,
         value: 1
+      },
+      _colorsAreSet: {
+        type: Boolean,
       }
     },
     observers: [
       '_xAxisConfigChanged(xAxisConfig.*)',
       '_yAxisConfigChanged(yAxisConfig.*)',
       '_positionChanged(_center, _radius)',
-      '_drawTitle(svg, showTitle, title, _total, _internalUnits, titleSpacing)',
+      '_drawTitle(svg, showTitle, title, _total, _internalUnits, titleSpacing, _colorsAreSet)',
       '_resetColors(seriesColorList.*)'
     ],
     listeners: {
@@ -340,7 +343,8 @@ Custom property | Description
       'px-vis-pie-centered-on-slice': '_showPopover',
       'px-vis-pie-mouse-enter-slice': '_showTooltip',
       'px-vis-pie-slice-clicked': '_hideTooltip',
-      'px-vis-pie-mouse-leave-slice': '_hideTooltip'
+      'px-vis-pie-mouse-leave-slice': '_hideTooltip',
+      'px-data-vis-colors-applied' : '_colorsSet'
     },
     ready: function() {
       this.xAxisType = 'pie';
@@ -413,6 +417,11 @@ Custom property | Description
         this._titleGroup = null;
       }
     },
+
+    _colorsSet: function() {
+      this.set('_colorsAreSet', true);
+    },
+
     _getInternalData: function(chartData, completeSeriesConfig) {
       if(this._isObjEmpty(this.completeSeriesConfig)) {
         return;

--- a/px-vis-pie-chart.html
+++ b/px-vis-pie-chart.html
@@ -326,16 +326,13 @@ Custom property | Description
       _forceColorsUpdate: {
         type: Number,
         value: 1
-      },
-      _colorsAreSet: {
-        type: Boolean,
       }
     },
     observers: [
       '_xAxisConfigChanged(xAxisConfig.*)',
       '_yAxisConfigChanged(yAxisConfig.*)',
       '_positionChanged(_center, _radius)',
-      '_drawTitle(svg, showTitle, title, _total, _internalUnits, titleSpacing, _colorsAreSet)',
+      '_drawTitle(svg, showTitle, title, _total, _internalUnits, titleSpacing, _stylesUpdated)',
       '_resetColors(seriesColorList.*)'
     ],
     listeners: {
@@ -350,6 +347,9 @@ Custom property | Description
       this.xAxisType = 'pie';
       this.yAxisType = 'pie';
       this.includeAllSeries = true;
+      window.requestAnimationFrame(function() {
+        this.updateStyles();
+      }.bind(this));
     },
     attached: function() {
       this._onIronResize();
@@ -384,42 +384,46 @@ Custom property | Description
             .attr('class','title-group');
 
           this._titleGroup.append('text')
-              .attr('class','title')
-              .attr('fill', this._checkThemeVariable('--px-vis-pie-title-color', 'rgb(0,0,0)'))
-              .attr('font-size', this._checkThemeVariable('--px-vis-pie-title-font-size', '45px'))
-              .style('font-family',this._checkThemeVariable("--px-vis-font-family", ''))
-              .attr('font-style', this._checkThemeVariable("--px-vis-font-family", ''))
-              .text(this.title)
-              .attr('text-anchor', 'middle')
-              .attr('transform','translate(0,' + '-' + this.titleSpacing + ')');
+            .attr('class','title')
+            .attr('fill', this._checkThemeVariable('--px-vis-pie-title-color', 'rgb(0,0,0)'))
+            .attr('font-size', this._checkThemeVariable('--px-vis-pie-title-font-size', '45px'))
+            .style('font-family',this._checkThemeVariable("--px-vis-font-family", ''))
+            .attr('font-style', this._checkThemeVariable("--px-vis-font-family", ''))
+            .text(this.title)
+            .attr('text-anchor', 'middle')
+            .attr('transform','translate(0,' + '-' + this.titleSpacing + ')');
 
           this._titleGroup.append('text')
-              .attr('class','value')
-              .attr('fill', this._checkThemeVariable('--px-vis-pie-title-value-color', 'rgb(0,0,0)'))
-              .attr('font-size', this._checkThemeVariable('--px-vis-pie-title-value-font-size', '45px'))
-              .style('font-family',this._checkThemeVariable("--px-vis-font-family", ''))
-              .attr('font-style', this._checkThemeVariable("--px-vis-font-family", ''))
-              .text(this._total + ' ' + this._currentConfig.xAxisUnit)
-              .attr('text-anchor', 'middle')
-              .attr('alignment-baseline', 'hanging')
-              .attr('transform','translate(0,' + this.titleSpacing + ')');
+            .attr('class','value')
+            .attr('fill', this._checkThemeVariable('--px-vis-pie-title-value-color', 'rgb(0,0,0)'))
+            .attr('font-size', this._checkThemeVariable('--px-vis-pie-title-value-font-size', '45px'))
+            .style('font-family',this._checkThemeVariable("--px-vis-font-family", ''))
+            .attr('font-style', this._checkThemeVariable("--px-vis-font-family", ''))
+            .text(this._total + ' ' + this._currentConfig.xAxisUnit)
+            .attr('text-anchor', 'middle')
+            .attr('alignment-baseline', 'hanging')
+            .attr('transform','translate(0,' + this.titleSpacing + ')');
         } else {
           this._titleGroup.select('text.title')
-                          .text(this.title)
-                          .attr('transform','translate(0,' + '-' + this.titleSpacing + ')');
+            .attr('fill', this._checkThemeVariable('--px-vis-pie-title-color', 'rgb(0,0,0)'))
+            .attr('font-size', this._checkThemeVariable('--px-vis-pie-title-font-size', '45px'))
+            .style('font-family',this._checkThemeVariable("--px-vis-font-family", ''))
+            .attr('font-style', this._checkThemeVariable("--px-vis-font-family", ''))
+            .text(this.title)
+            .attr('transform','translate(0,' + '-' + this.titleSpacing + ')');
 
           this._titleGroup.select('text.value')
-              .text(this._total + ' ' + this._currentConfig.xAxisUnit)
-              .attr('transform','translate(0,' + this.titleSpacing + ')');
+            .attr('fill', this._checkThemeVariable('--px-vis-pie-title-value-color', 'rgb(0,0,0)'))
+            .attr('font-size', this._checkThemeVariable('--px-vis-pie-title-value-font-size', '45px'))
+            .style('font-family',this._checkThemeVariable("--px-vis-font-family", ''))
+            .attr('font-style', this._checkThemeVariable("--px-vis-font-family", ''))
+            .text(this._total + ' ' + this._currentConfig.xAxisUnit)
+            .attr('transform','translate(0,' + this.titleSpacing + ')');
         }
       } else if (this._titleGroup) {
         this._titleGroup.remove();
         this._titleGroup = null;
       }
-    },
-
-    _colorsSet: function() {
-      this.set('_colorsAreSet', true);
     },
 
     _getInternalData: function(chartData, completeSeriesConfig) {

--- a/test/px-vis-pie-chart-custom-tests.js
+++ b/test/px-vis-pie-chart-custom-tests.js
@@ -1,9 +1,8 @@
 document.addEventListener("WebComponentsReady", function() {
-  runCustomTests1();
-  runCustomTests2();
+  runCustomTests();
 });
 
-function runCustomTests1() {
+function runCustomTests() {
 
   var pie,
       donut;
@@ -209,27 +208,17 @@ function runCustomTests1() {
 
 
   });
-};
 
-function runCustomTests2() {
-  suiteSetup(function(done) {
-    var autoTemplate = document.querySelector('dom-bind');
-    autoTemplate.showMe = true;
-    setTimeout(function() {
-      conditionalDonut = document.getElementById('conditionalDonut');
-      done();
-    }, 500);
-  });
-
-  suite('Conditional Donut tests', function() {
+  suite('Fast Render', function() {
     test('conditional donut is created', function() {
-      assert.isTrue(conditionalDonut !== null);
+      assert.isTrue(donut2 !== null);
     });
 
     test('conditional donut has correct css variables applied', function() {
-      var themeVar = conditionalDonut._checkThemeVariable(conditionalDonut, '--px-vis-pie-title-color');
+      var themeVar = donut2._checkThemeVariable(donut2, '--px-vis-pie-title-color');
       assert.equal(themeVar, '--px-vis-pie-title-color', 'theme-var not set');
-      assert.notEqual(conditionalDonut.$.svg.shadowRoot.querySelector('.title').getAttribute('fill'), 'rgb(0,0,0)');
+      assert.notEqual(Polymer.dom(donut2.$.svg.root).querySelector('.title').getAttribute('fill'), 'rgb(0,0,0)');
     });
   });
-}
+};
+

--- a/test/px-vis-pie-chart-custom-tests.js
+++ b/test/px-vis-pie-chart-custom-tests.js
@@ -218,7 +218,7 @@ function runCustomTests2() {
     setTimeout(function() {
       conditionalDonut = document.getElementById('conditionalDonut');
       done();
-    }, 200);
+    }, 500);
   });
 
   suite('Conditional Donut tests', function() {
@@ -227,9 +227,9 @@ function runCustomTests2() {
     });
 
     test('conditional donut has correct css variables applied', function() {
-      var themeVar = conditionalDonut._checkThemeVariable(conditionalDonut, '--px-vis-pie-title-color')
+      var themeVar = conditionalDonut._checkThemeVariable(conditionalDonut, '--px-vis-pie-title-color');
       assert.equal(themeVar, '--px-vis-pie-title-color', 'theme-var not set');
       assert.notEqual(conditionalDonut.$.svg.shadowRoot.querySelector('.title').getAttribute('fill'), 'rgb(0,0,0)');
-    })
+    });
   });
 }

--- a/test/px-vis-pie-chart-custom-tests.js
+++ b/test/px-vis-pie-chart-custom-tests.js
@@ -1,8 +1,9 @@
 document.addEventListener("WebComponentsReady", function() {
-  runCustomTests();
+  runCustomTests1();
+  runCustomTests2();
 });
 
-function runCustomTests() {
+function runCustomTests1() {
 
   var pie,
       donut;
@@ -209,3 +210,26 @@ function runCustomTests() {
 
   });
 };
+
+function runCustomTests2() {
+  suiteSetup(function(done) {
+    var autoTemplate = document.querySelector('dom-bind');
+    autoTemplate.showMe = true;
+    setTimeout(function() {
+      conditionalDonut = document.getElementById('conditionalDonut');
+      done();
+    }, 200);
+  });
+
+  suite('Conditional Donut tests', function() {
+    test('conditional donut is created', function() {
+      assert.isTrue(conditionalDonut !== null);
+    });
+
+    test('conditional donut has correct css variables applied', function() {
+      var themeVar = conditionalDonut._checkThemeVariable(conditionalDonut, '--px-vis-pie-title-color')
+      assert.equal(themeVar, '--px-vis-pie-title-color', 'theme-var not set');
+      assert.notEqual(conditionalDonut.$.svg.shadowRoot.querySelector('.title').getAttribute('fill'), 'rgb(0,0,0)');
+    })
+  });
+}

--- a/test/px-vis-pie-chart-test-fixture.html
+++ b/test/px-vis-pie-chart-test-fixture.html
@@ -61,6 +61,22 @@
             "type": "horizontal"}'>
         </px-vis-pie-chart>
       </div>
+
+      <div>
+        <template is="dom-if" if="[[showMe]]">
+        <px-vis-pie-chart
+          id="conditionalDonut"
+          donut
+          chart-data='[{"x":1,"y":"half"},{"x":1,"y":"other"}]' 
+          width="400"
+          height="400"
+          show-title
+          title="Title"
+          series-config='{"tests":{"xAxisUnit":"","y":"y","x":"x"}}' 
+          ></px-vis-pie-chart>
+        </template>
+      </div>
+
     </template>
   </dom-bind>
   </body>

--- a/test/px-vis-pie-chart-test-fixture.html
+++ b/test/px-vis-pie-chart-test-fixture.html
@@ -63,9 +63,8 @@
       </div>
 
       <div>
-        <template is="dom-if" if="[[showMe]]">
         <px-vis-pie-chart
-          id="conditionalDonut"
+          id="donut2"
           donut
           chart-data='[{"x":1,"y":"half"},{"x":1,"y":"other"}]' 
           width="400"
@@ -74,7 +73,6 @@
           title="Title"
           series-config='{"tests":{"xAxisUnit":"","y":"y","x":"x"}}' 
           ></px-vis-pie-chart>
-        </template>
       </div>
 
     </template>


### PR DESCRIPTION
* ## A description of the changes proposed in the pull request:

This PR defers the drawing of the title until css variables are applied.
That prevents the *title-text* and the *title-value* to be drawn with the default styles as highlighted in #48.

* ## A reference to a related issue (if applicable):

#48

* ## @mentions of the person or team responsible for reviewing proposed changes:

@nonmetalhail @randyaskin 

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.

test added in 4c2a6e1